### PR TITLE
Various improvements, including using a set email address

### DIFF
--- a/GuerrillaMail.cs
+++ b/GuerrillaMail.cs
@@ -209,6 +209,12 @@ namespace GuerrillaMailExample
         /// <summary>
         /// Email address name
         /// </summary>
+        private string mEmailAddress;
+
+
+        /// <summary>
+        /// Email address name
+        /// </summary>
         private string mEmailAlias;
 
 
@@ -259,7 +265,8 @@ namespace GuerrillaMailExample
         {
             /*Initialize the inbox*/
             JObject Obj = JObject.Parse(Contact("f=get_email_address"));
-            mEmailAlias = ((string)Obj.SelectToken("email_addr")).Split('@')[0];
+            mEmailAddress = ((string)Obj.SelectToken("email_addr")).Split('@')[0];
+            mEmailAlias = (string)Obj.SelectToken("alias");
 
             /*Delete the automatic welcome email - id is always 1*/
             DeleteSingleEmail("1");
@@ -320,28 +327,51 @@ namespace GuerrillaMailExample
         {
             /*There are several email domains you can use by default*/
             /*Some sites may block guerrilla mail domains, so we can use several different ones*/
-            string address = string.Format("{0}@", mEmailAlias);
+            return string.Format("{0}@", mEmailAddress) + GetDomain(domain);
+        }
+
+
+        /// <summary>
+        /// Returns our alias with a specified domain
+        /// </summary>
+        /// <param name="domain">Specifies which domain to return (0-8) useful for services that blocks certain domains</param>
+        /// <returns>Returns email as string</returns>
+        public string GetMyAlias(int domain = 0)
+        {
+            /*There are several email domains you can use by default*/
+            /*Some sites may block guerrilla mail domains, so we can use several different ones*/
+            return string.Format("{0}@", mEmailAlias) + GetDomain(domain);
+        }
+
+
+        /// <summary>
+        /// Get the domain matching the given parameter.
+        /// </summary>
+        /// <param name="domain">Specifies which domain to return (0-8) useful for services that blocks certain domains</param>
+        /// <returns></returns>
+        private static string GetDomain(int domain)
+        {
             switch (domain)
             {
                 case 1:
-                    return address + "grr.la";
+                    return "grr.la";
                 case 2:
-                    return address + "guerrillamail.biz";
+                    return "guerrillamail.biz";
                 case 3:
-                    return address + "guerrillamail.com";
+                    return "guerrillamail.com";
                 case 4:
-                    return address + "guerrillamail.de";
+                    return "guerrillamail.de";
                 case 5:
-                    return address + "guerrillamail.net";
+                    return "guerrillamail.net";
                 case 6:
-                    return address + "guerrillamail.org";
+                    return "guerrillamail.org";
                 case 7:
-                    return address + "guerrillamailblock.com";
+                    return "guerrillamailblock.com";
                 case 8:
-                    return address + "spam4.me";
+                    return "spam4.me";
 
                 default:
-                    return address + "sharklasers.com";
+                    return "sharklasers.com";
             }
         }
 

--- a/GuerrillaMail.cs
+++ b/GuerrillaMail.cs
@@ -224,7 +224,7 @@ namespace GuerrillaMailExample
         /// <summary>
         /// Initializer for the class with proxy
         /// </summary>
-        /// <param name="Proxy">Proxy address to request through</param>
+        /// <param name="proxy">Proxy address to request through</param>
         public GuerrillaMail(string proxy)
         {
             /*If we got passed a Proxy variable*/
@@ -283,8 +283,7 @@ namespace GuerrillaMailExample
         /// <returns>Returns list of email</returns>
         public List<Email> GetAllEmails()
         {
-            var emails = JsonConvert.DeserializeObject<Response>(Contact("f=get_email_list&offset=0"));
-            return emails.list;
+            return GetContent().list;
         }
 
 
@@ -308,8 +307,7 @@ namespace GuerrillaMailExample
         /// <returns>Returns null if no email</returns>
         public Email GetLastEmail()
         {
-            var emails = JsonConvert.DeserializeObject<Response>(Contact("f=get_email_list&offset=0"));
-            return emails.list.LastOrDefault();
+            return GetAllEmails().LastOrDefault();
         }
 
 
@@ -352,34 +350,15 @@ namespace GuerrillaMailExample
         /// Deletes an array of emails from the mailbox
         /// </summary>
         /// <param name="mail_ids">String array of mail ids</param>
-        public void DeleteEmails(string[] mail_ids)
+        public void DeleteEmails(IEnumerable<string> mail_ids)
         {
-            /*If there are at least 1 ID in the array*/
-            if (mail_ids.Length > 0)
-            {
-                /*Go through each array value and format delete string*/
-                string idString = string.Empty;
-                foreach (string id in mail_ids)
-                {
-                    /*Example: &email_ids[]53666&email_ids[]53667*/
-                    idString += string.Format("&email_ids[]{0}", id);
-                }
-
-                /*Delete emails*/
-                Contact("f=del_email" + idString);
-            }
-        }
-
-
-        /// <summary>
-        /// Deletes an array of emails from the mailbox
-        /// </summary>
-        /// <param name="mail_ids">List string of mail ids</param>
-        public void DeleteEmails(List<string> mail_ids)
-        {
-            /*Format email delete string*/
+            /*Go through each array value and format delete string*/
             string idString = string.Empty;
-            mail_ids.ForEach(o => idString += string.Format("&email_ids[]{0}", o));
+            foreach (string id in mail_ids)
+            {
+                /*Example: &email_ids[]53666&email_ids[]53667*/
+                idString += string.Format("&email_ids[]{0}", id);
+            }
 
             /*Delete emails*/
             Contact("f=del_email" + idString);

--- a/GuerrillaMail.cs
+++ b/GuerrillaMail.cs
@@ -32,7 +32,7 @@ namespace GuerrillaMailExample
             /// <summary>
             /// ID of email
             /// </summary>
-            public object mail_id { get; set; }
+            public int mail_id { get; set; }
 
 
             /// <summary>
@@ -293,6 +293,12 @@ namespace GuerrillaMailExample
         public Email GetLastEmail()
         {
             return GetAllEmails().LastOrDefault();
+        }
+
+        public Email GetEmail(int mail_id)
+        {
+            var emails = JsonConvert.DeserializeObject<Email>(Contact("f=fetch_email&email_id=mr_" + mail_id));
+            return emails;
         }
 
 

--- a/GuerrillaMail.cs
+++ b/GuerrillaMail.cs
@@ -416,7 +416,6 @@ namespace GuerrillaMailExample
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create("http://api.guerrillamail.com/ajax.php?" + parameters);
             request.CookieContainer = mCookies;
             request.Method = "GET";
-            request.Host = "www.guerrillamail.com";
             request.UserAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36";
             request.Accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8";
 


### PR DESCRIPTION
List of changes:
- Some code rewriting (less code duplication)
- Added changed `mEmailAlias` to `mEmailAddress`
- Added `mEmailAlias`, which contains the actual alias, and expose it through `GetMyAlias`
- Use `WebProxy` class instead of accepting a string and parsing it yourself
- Allow the user to pick an email address, instead of being assigned one
- Fix a bug where the Host header was being set incorrectly, allowing for POST requests again
- Allow the user to fetch a single mail to read the body

I needed some of these changes for a project of my own, but I followed your code style so you can merge it if you wish. The code should also be clearer/shorter now.